### PR TITLE
setup file fix - now supports venv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ setup(
         'Programming Language :: Python :: 3.7',
     ],
     python_requires='>=3.7.0',
-    install_requires=['scipy', 'matplotlib', 'pytest', 'pygears'],
-    setup_requires=['scipy', 'matplotlib', 'pytest', 'pygears'],
+    install_requires=['scipy', 'matplotlib', 'pygears', 'pytest'],
     package_data={'': ['*.j2', '*.sv']},
     include_package_data=True,
     keywords=


### PR DESCRIPTION
previously there was an issue when doing "pip install -e ." within vevn
fixed by keeping only intall_requirements in the setup.py file